### PR TITLE
Skip decorated members in no-private-modifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aneuhold/eslint-config",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Main ESLint Configuration for personal projects",
   "main": "./src/configs/ts-lib-config.ts",
   "packageManager": "pnpm@10.33.0",

--- a/src/rules/no-private-modifier/classFrame.ts
+++ b/src/rules/no-private-modifier/classFrame.ts
@@ -3,13 +3,16 @@ import { type ClassFrame, type ClassNode } from './types';
 
 /**
  * Creates a fresh frame for a class, scanning its members up-front for the
- * private names eligible to convert and the `#names` already in use.
+ * private names eligible to convert and the `#names` already in use. Decorated
+ * members are excluded and their names blocked, since TypeScript rejects
+ * decorators on `#private` members (`TS1206`).
  *
  * @param classNode The class declaration or expression
  */
 export const createClassFrame = (classNode: ClassNode): ClassFrame => {
   const candidateNames = new Set<string>();
   const existingPrivateNames = new Set<string>();
+  const decoratedNames = new Set<string>();
 
   for (const member of classNode.body.body) {
     if (
@@ -26,8 +29,18 @@ export const createClassFrame = (classNode: ClassNode): ClassFrame => {
       member.key.type === AST_NODE_TYPES.Identifier &&
       member.accessibility === 'private'
     ) {
-      candidateNames.add(member.key.name);
+      if (member.decorators.length > 0) {
+        decoratedNames.add(member.key.name);
+      } else {
+        candidateNames.add(member.key.name);
+      }
     }
+  }
+
+  // A name shared with a decorated member (such as a get/set pair where only
+  // one carries the decorator) has to stay put, so the pair keeps matching.
+  for (const name of decoratedNames) {
+    candidateNames.delete(name);
   }
 
   return {
@@ -37,7 +50,7 @@ export const createClassFrame = (classNode: ClassNode): ClassFrame => {
     existingPrivateNames,
     thisRefs: new Map(),
     staticRefs: new Map(),
-    blocked: new Set(),
+    blocked: decoratedNames,
     rebindDepth: 0,
   };
 };

--- a/src/rules/no-private-modifier/classReports.ts
+++ b/src/rules/no-private-modifier/classReports.ts
@@ -11,6 +11,7 @@ export type ClassReports = { reports: MemberReport[]; targets: FixTarget[] };
  * Turns a fully-populated frame into the per-member reports and the set of
  * fixable conversion targets. Each name claims its references once, so a
  * get/set pair sharing a name doesn't rewrite the same reference twice.
+ * Decorated members are skipped entirely — neither reported nor converted.
  *
  * @param frame The class frame, after traversal has recorded its references
  */
@@ -31,6 +32,9 @@ export const collectClassReports = (frame: ClassFrame): ClassReports => {
       continue;
     }
     if (member.type === AST_NODE_TYPES.MethodDefinition && member.kind === 'constructor') {
+      continue;
+    }
+    if (member.decorators.length > 0) {
       continue;
     }
 

--- a/src/rules/no-private-modifier/no-private-modifier.md
+++ b/src/rules/no-private-modifier/no-private-modifier.md
@@ -27,6 +27,13 @@ is a concise, readable shorthand that declares and assigns the field in one
 place, and `#private` has no equivalent. Flagging it would force the verbose
 field-plus-assignment form for no real benefit, so the rule permits it.
 
+**Decorated members are allowed.** TypeScript rejects decorators on `#private`
+fields and methods with `TS1206: Decorators are not valid here.`, so a decorated
+member has no `#` form to convert to. Reporting one would only force an
+`eslint-disable` comment for something that cannot be fixed, so the rule skips
+it — no report, and neither the declaration nor its `this.name` references are
+rewritten.
+
 ## Autofix
 
 None. Converting `private` to `#` requires renaming every reference
@@ -64,6 +71,10 @@ class Counter {
 class Service {
   // Parameter properties are allowed.
   constructor(private readonly client: Client) {}
+
+  // Decorated members are allowed.
+  @WebSocketServer()
+  private server!: SocketServer;
 }
 ```
 

--- a/src/rules/no-private-modifier/no-private-modifier.test.ts
+++ b/src/rules/no-private-modifier/no-private-modifier.test.ts
@@ -27,6 +27,9 @@ ruleTester.run('no-private-modifier', noPrivateModifier, {
     // Constructor parameter properties are allowed (no `#` shorthand exists).
     { code: `class Foo { constructor(private foo: string) {} }` },
     { code: `class Foo { constructor(private readonly foo: string) {} }` },
+    // Decorated members are allowed (decorators are invalid on `#private`).
+    { code: `class Foo { @Inject() private client!: Client; }` },
+    { code: `class Foo { @Log() private helper(): void {} }` },
     // `public`/`protected`/no-modifier members are out of scope.
     { code: `class Foo { public count = 0; }` },
     { code: `class Foo { protected helper(): void {} }` },
@@ -94,6 +97,13 @@ ruleTester.run('no-private-modifier', noPrivateModifier, {
       code: `class Foo { private val = 1; read() { const { val } = this; return val; } }`,
       errors: [{ messageId: 'privateField' }],
       output: null,
+    },
+    // A decorated member sits out the conversion entirely, references included,
+    // while an undecorated sibling still converts.
+    {
+      code: `class Foo { @Inject() private client!: Client; private count = 0; run() { this.client.send(this.count); } }`,
+      errors: [{ messageId: 'privateField' }],
+      output: `class Foo { @Inject() private client!: Client; #count = 0; run() { this.client.send(this.#count); } }`,
     },
     // A colliding `#count` already exists, so the rename is unsafe — report only.
     {

--- a/src/rules/no-private-modifier/no-private-modifier.ts
+++ b/src/rules/no-private-modifier/no-private-modifier.ts
@@ -10,9 +10,9 @@ import { type ClassFrame, type ClassNode } from './types';
  * syntax rather than the TypeScript `private` accessibility modifier, and
  * autofixes the conversion — declaration plus `this.x` / `ClassName.x`
  * references — whenever it can do so safely. Covers instance and static fields,
- * and methods (including accessors and getters/setters). Private constructors
- * and constructor parameter properties (`constructor(private foo)`) are
- * intentionally allowed, since the `#` form has no equivalent.
+ * and methods (including accessors and getters/setters). Private constructors,
+ * constructor parameter properties (`constructor(private foo)`), and decorated
+ * members are intentionally allowed, since the `#` form has no equivalent.
  *
  * References are gathered as ESLint makes its single pass over the file: a stack
  * tracks the class currently being traversed, and a per-class counter tracks how

--- a/src/rules/no-private-modifier/types.ts
+++ b/src/rules/no-private-modifier/types.ts
@@ -31,7 +31,7 @@ export type ClassFrame = {
   thisRefs: Map<string, TSESTree.MemberExpression[]>;
   /** `ClassName.name` accesses (statics) that an autofix would rewrite. */
   staticRefs: Map<string, TSESTree.MemberExpression[]>;
-  /** Names with a reference the fix can't safely rewrite, so won't be touched. */
+  /** Names the fix can't safely rewrite, so won't be touched. */
   blocked: Set<string>;
   /**
    * How many non-arrow functions are currently open inside this class without


### PR DESCRIPTION
## Summary

TypeScript rejects decorators on `#private` fields and methods (`TS1206: Decorators are not valid here.`), so a decorated `private` member has no `#` form to convert to. Reporting one only forces an `eslint-disable` comment for something that cannot be fixed.

The `no-private-modifier` rule now skips decorated members entirely: no report, and neither the declaration nor its `this.name` references are rewritten. A name shared with a decorated member (such as a get/set pair where only one carries the decorator) is blocked too, so the pair keeps matching.

Also bumps the patch version to 3.0.2.

## Test plan

- New valid cases for decorated fields and methods
- New invalid case where a decorated member sits out the conversion while an undecorated sibling still converts
- `pnpm check`, `pnpm lint`, `pnpm test` pass locally (46 tests)